### PR TITLE
Fix gem dependencies

### DIFF
--- a/url_validator.gemspec
+++ b/url_validator.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activemodel', '>= 4.0.0', '< 6'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/url_validator.gemspec
+++ b/url_validator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rails', '>= 3.0.0'
+  spec.add_runtime_dependency 'rails', '>= 4.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/url_validator.gemspec
+++ b/url_validator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rails', '>= 4.0.0'
+  spec.add_runtime_dependency 'activemodel', '>= 4.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/url_validator.gemspec
+++ b/url_validator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activemodel', '>= 4.0.0'
+  spec.add_runtime_dependency 'activemodel', '>= 4.0.0', '< 6'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/url_validator.gemspec
+++ b/url_validator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 3.0.0'
+  spec.add_runtime_dependency 'rails', '>= 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Use Pry in development. Replace Rails dependency with ActiveModel's, limit it to versions 4 & 5.